### PR TITLE
Grab symbols for all releases by default, plus skip already-grabbed versions

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -1,20 +1,13 @@
 #!/usr/bin/env bash
 set -eux
 
-MUON_URL="https://github.com/brave/electron/releases/download"
+MUON_URL="https://github.com/brave/muon/releases/download"
 CORE_URL="https://github.com/brave/brave-browser-builds/releases/download"
 
-MUON_VERSIONS="${MUON_VERSIONS:-}"
-CORE_VERSIONS="${CORE_VERSIONS:-}"
+MUON_VERSIONS="${CORE_VERSIONS:-$(curl -s https://api.github.com/repos/brave/muon/releases| jq .[].tag_name| sed 's/^"v//g; s/"$//g')}"
+CORE_VERSIONS="${CORE_VERSIONS:-$(curl -s https://api.github.com/repos/brave/brave-browser-builds/releases| jq .[].tag_name| sed 's/^"v//g; s/"$//g')}"
 
 FORCE_UNZIP="${FORCE_UNZIP:-}"
-
-if [ -z "$MUON_VERSIONS" ] && [ -z "$CORE_VERSIONS" ]; then
-    echo "Error, missing MUON_VERSIONS or CORE_VERSIONS environment variables. Please set."
-    exit 1
-fi
-
-echo $CORE_URL
 
 for VERSION in $MUON_VERSIONS
 do
@@ -23,14 +16,14 @@ do
 
     if [ "$(which bsdtar)" ] && [ ! "$FORCE_UNZIP" ]; then
         cmd="bsdtar -xvf-"
-        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" | $cmd )
-        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
-        ( cd "symbols/darwin-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
+        test -f "symbols/win32-ia32-$VERSION/LICENSE" || ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" | $cmd )
+        test -f "symbols/win32-x64-$VERSION/LICENSE" || ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
+        test -f "symbols/darwin-$VERSION/LICENSE" || ( cd "symbols/darwin-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
     elif [ "$(which unzip)" ]; then
         cmd="unzip -x"
-        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" > /tmp/win32-ia32.zip ; $cmd /tmp/win32-ia32.zip ; rm /tmp/win32-ia32.zip)
-        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
-        ( cd "symbols/darwin-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
+        test -f "symbols/win32-ia32-$VERSION/LICENSE" || ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" > /tmp/win32-ia32.zip ; $cmd /tmp/win32-ia32.zip ; rm /tmp/win32-ia32.zip)
+        test -f "symbols/win32-x64-$VERSION/LICENSE" || ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
+        test -f "symbols/darwin-$VERSION/LICENSE" || ( cd "symbols/darwin-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
     fi
 done
 
@@ -40,11 +33,11 @@ do
     mkdir -p symbols/{win32-ia32-$VERSION,win32-x64-$VERSION,darwin-$VERSION,linux-$VERSION}
     if [ "$(which bsdtar)" ] && [ ! "$FORCE_UNZIP" ]; then
         cmd="bsdtar -xvf-"
-        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
-        ( cd "symbols/darwin-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
+        test -f "symbols/win32-x64-$VERSION/LICENSE" || ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
+        test -f "symbols/darwin-$VERSION/LICENSE" || ( cd "symbols/darwin-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
     elif [ "$(which unzip)" ]; then
         cmd="unzip -x"
-        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
-        ( cd "symbols/darwin-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
+        test -f "symbols/win32-x64-$VERSION/LICENSE" || ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
+        test -f "symbols/darwin-$VERSION/LICENSE" || ( cd "symbols/darwin-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
     fi
 done

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-symbol-fetcher",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Install brave debug symbols using npm",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit alters fetch.sh to grab symbols for all releases from each project. Manual overrides with CORE_VERSIONS and MUON_VERSIONS is still available.
It also tests to see if a versoin has already been grabbed locally, and if it has been it will skip downloading and extracting.